### PR TITLE
Fixes for gx-pivot

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "date-fns": "^2.30.0",
     "highcharts": "^11.1.0",
     "jquery": "^3.7.1",
-    "jspivottable": "1.1.9",
+    "jspivottable": "1.2.3",
     "material-icons": "^1.13.1",
     "rollup-plugin-dotenv": "^0.5.0"
   }

--- a/src/components/query-viewer-pivot-table/query-viewer-pivot.tsx
+++ b/src/components/query-viewer-pivot-table/query-viewer-pivot.tsx
@@ -274,10 +274,9 @@ export class QueryViewerPivot {
   };
 
   @Listen("RequestPageDataForPivotTable", {
-    target: "document",
     capture: true
   })
-  @Listen("RequestPageDataForTable", { target: "document", capture: true })
+  @Listen("RequestPageDataForTable", { capture: true })
   handleRequestPageDataForTable(event) {
     const pageData: QueryViewerPageDataForTable | QueryViewerPageDataForPivot =
       (event as any).parameter;

--- a/src/components/query-viewer/query-viewer.tsx
+++ b/src/components/query-viewer/query-viewer.tsx
@@ -443,7 +443,7 @@ export class QueryViewer {
     this.setQueryViewerProperties(event.detail.Properties);
   }
 
-  @Listen("RequestPageDataForPivotTable", { target: "document" })
+  @Listen("RequestPageDataForPivotTable")
   handleRequestPageDataForPivotTable(
     event: CustomEvent<QueryViewerPageDataForPivot>
   ) {
@@ -460,7 +460,7 @@ export class QueryViewer {
     }
   }
 
-  @Listen("RequestAttributeValuesForPivotTable", { target: "document" })
+  @Listen("RequestAttributeValuesForPivotTable")
   handleAttributeValuesForPivotTable(
     event: CustomEvent<QueryViewerAttributesValuesForPivot>
   ) {
@@ -512,7 +512,7 @@ export class QueryViewer {
 
   /** Table Services **/
 
-  @Listen("RequestPageDataForTable", { target: "document" })
+  @Listen("RequestPageDataForTable")
   handleRequestPageDataForTable(
     event: CustomEvent<QueryViewerPageDataForTable>
   ) {
@@ -534,7 +534,7 @@ export class QueryViewer {
     this.pageDataForTable = event.detail;
   }
 
-  @Listen("RequestAttributeForTable", { target: "document" })
+  @Listen("RequestAttributeForTable")
   handleAttributeForTable(
     event: CustomEvent<QueryViewerAttributesValuesForTable>
   ) {


### PR DESCRIPTION
**Changes we proposed in this PR:**

- Bump jspivottable from 1.1.9 to 1.2.3
- Remove 'target: document' in the @Listen are now dispatched on the ref container